### PR TITLE
Braydon kains/add old cs proj

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ nmap <silent> <buffer> <LocalLeader>ossp <Plug>(omnisharp_stop_server)
 If the `g:sharpenup_legacy_csproj_actions` flag is set the following mappings will be set:
 
 ```vim
-nmap <silent> <buffer> <LocalLeader>add :call legacycsproj#AddToProject()<CR>
-nmap <silent> <buffer> <LocalLeader>ren :call legacycsproj#RenameInProject()<Left>
+nmap <silent> <buffer> <LocalLeader>add :call sharpenup#legacycsproj#AddToProject()<CR>
+nmap <silent> <buffer> <LocalLeader>ren :call sharpenup#legacycsproj#RenameInProject()<Left>
 ```
 
 The mappings all use a common prefix, except for these exceptions: `gd`, `<C-\>`, `[[`, `]]`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A flag is displayed in the sign column to indicate that one or more code actions
 | `g:sharpenup_codeactions_autocmd`        | `'CursorHold'` | Which autocmd to trigger on - can be a comma separated list. Suggestions: `CursorHold`, `CursorMoved`, `BufEnter,CursorMoved` |
 | `g:sharpenup_codeactions_glyph`          | `'💡'`         | Select the character to be used as the sign-column indicator |
 | `g:sharpenup_codeactions_set_signcolumn` | `1`            | `'signcolumn'` will be set to `yes` for .cs buffers          |
+| `g:sharpenup_legacy_csproj_actions`      | `1`            | Add bindings for legacy csproj actions                       | 
 
 ## Statusline
 
@@ -163,6 +164,13 @@ nmap <silent> <buffer> <LocalLeader>os= <Plug>(omnisharp_code_format)
 nmap <silent> <buffer> <LocalLeader>osre <Plug>(omnisharp_restart_server)
 nmap <silent> <buffer> <LocalLeader>osst <Plug>(omnisharp_start_server)
 nmap <silent> <buffer> <LocalLeader>ossp <Plug>(omnisharp_stop_server)
+```
+
+If the `g:sharpenup_legacy_csproj_actions` flag is set the following mappings will be set:
+
+```vim
+nmap <silent> <buffer> <LocalLeader>add :call legacycsproj#AddToProject()<CR>
+nmap <silent> <buffer> <LocalLeader>ren :call legacycsproj#RenameInProject()<Left>
 ```
 
 The mappings all use a common prefix, except for these exceptions: `gd`, `<C-\>`, `[[`, `]]`

--- a/autoload/sharpenup/legacycsproj.vim
+++ b/autoload/sharpenup/legacycsproj.vim
@@ -1,0 +1,75 @@
+" Search from the current directory up to the solution directory for a .csproj
+" file, and return the first one found. Note that this may return the wrong
+" .csproj file if two .csproj files are found in the same directory.
+function! s:FindProject() abort
+  let l:base = fnamemodify(OmniSharp#FindSolutionOrDir(), ':h')
+  let l:dir = expand('%:p:h')
+  while 1
+    let l:projects = split(globpath(l:dir, '*.csproj'), '\n')
+    if len(l:projects)
+      return l:projects[0]
+    endif
+    let l:parent = fnamemodify(l:dir, ':h')
+    if l:dir ==# l:parent || l:dir ==# l:base
+      echohl WarningMsg | echomsg 'Project not found' | echohl None
+      return ''
+    endif
+    let l:dir = l:parent
+  endwhile
+endfunction
+
+" Add the current file to the .csproj. The .csproj must be found in an ancestor
+" directory and must already contain at least one .cs file.
+function! sharpenup#legacycsproj#AddToProject() abort
+  let l:filename = expand('%:p')
+  let l:project = s:FindProject()
+  if !len(l:project) | return | endif
+  execute 'silent tabedit' l:project
+  call cursor(1, 1)
+  if !search('^\s*<compile include=".*\.cs"', '')
+    tabclose
+    echohl WarningMsg | echomsg 'Could not find a .cs entry' | echohl None
+    return
+  endif
+  normal! yypk
+  if fnamemodify(l:project, ':h') !=# getcwd()
+    execute 'lcd' fnamemodify(l:project, ':h')
+  endif
+  execute 's/".*\.cs"/"' . fnamemodify(l:filename, ':.:gs?/?\\/?') . '"/'
+  if g:OmniSharp_translate_cygwin_wsl || has('win32')
+    s?/?\\?g
+    s?\\>?/>?g
+  endif
+  write
+  tabclose
+endfunction
+
+" Find the current file in the .csproj file and rename it to a:newname.
+" Do not pass in a full path - just the new filename.cs
+function! sharpenup#legacycsproj#RenameInProject(newname) abort
+  let l:filepath = expand('%:p')
+  let l:filename = expand('%:t')
+  let l:project = s:FindProject()
+  if !len(l:project) | return | endif
+  execute 'silent tabedit' l:project
+  call cursor(1, 1)
+  if fnamemodify(l:project, ':h') !=# getcwd()
+    execute 'lcd' fnamemodify(l:project, ':h')
+  endif
+  let l:filepath = fnamemodify(l:filepath, ':.')
+  if g:OmniSharp_translate_cygwin_wsl || has('win32')
+    let l:filepath = substitute(l:filepath, '/', '\\\\', 'g')
+  endif
+  " Search for the full file path, relative to the .csproj
+  if !search(l:filepath, '')
+    " If not found, try just the file name (without the path)
+    if !search(fnamemodify(l:filepath, ':t'), '')
+      tabclose
+      echohl WarningMsg | echomsg 'Could not find ' . l:filepath | echohl None
+      return
+    endif
+  endif
+  execute 's/' . fnamemodify(l:filename, ':t') . '/' . a:newname . '/'
+  write
+  tabclose
+endfunction

--- a/ftplugin/cs/sharpenup.vim
+++ b/ftplugin/cs/sharpenup.vim
@@ -68,4 +68,9 @@ if g:sharpenup_codeactions
   let b:undo_ftplugin .= '| execute "autocmd! sharpenup_ftplugin * <buffer>"'
 endif
 
+if g:sharpenup_legacy_csproj_actions
+  nmap <silent> <buffer> <LocalLeader>add :call legacycsproj#AddToProject()<CR>
+  nmap <silent> <buffer> <LocalLeader>ren :call legacycsproj#RenameInProject()<Left>
+endif
+
 " vim:et:sw=2:sts=2

--- a/ftplugin/cs/sharpenup.vim
+++ b/ftplugin/cs/sharpenup.vim
@@ -53,7 +53,7 @@ if get(g:, 'sharpenup_create_mappings', 1)
   
   if g:sharpenup_legacy_csproj_actions
     execute 'nmap <silent> <buffer>' . s:pre . 'add :call sharpenup#legacycsproj#AddToProject()<CR>'
-    execute 'nmap <silent> <buffer>' . s:pre . 'rem :call sharpenup#legacycsproj#RenameInProject()<Left>'
+    execute 'nmap <silent> <buffer>' . s:pre . 'ren :call sharpenup#legacycsproj#RenameInProject()<Left>'
   endif
 endif
 

--- a/ftplugin/cs/sharpenup.vim
+++ b/ftplugin/cs/sharpenup.vim
@@ -52,8 +52,8 @@ if get(g:, 'sharpenup_create_mappings', 1)
   call s:map('n', s:pre . 'rat', 'run_tests_in_file')
   
   if g:sharpenup_legacy_csproj_actions
-    execute 'nmap <silent> <buffer>' . s:pre . '<LocalLeader>add :call sharpenup#legacycsproj#AddToProject()<CR>'
-    execute 'nmap <silent> <buffer>' . s:pre . '<LocalLeader>ren :call sharpenup#legacycsproj#RenameInProject()<Left>'
+    execute 'nmap <silent> <buffer>' . s:pre . 'add :call sharpenup#legacycsproj#AddToProject()<CR>'
+    execute 'nmap <silent> <buffer>' . s:pre . 'ren :call sharpenup#legacycsproj#RenameInProject()<Left>'
   endif
 endif
 

--- a/ftplugin/cs/sharpenup.vim
+++ b/ftplugin/cs/sharpenup.vim
@@ -53,7 +53,7 @@ if get(g:, 'sharpenup_create_mappings', 1)
   
   if g:sharpenup_legacy_csproj_actions
     execute 'nmap <silent> <buffer>' . s:pre . 'add :call sharpenup#legacycsproj#AddToProject()<CR>'
-    execute 'nmap <silent> <buffer>' . s:pre . 'ren :call sharpenup#legacycsproj#RenameInProject()<Left>'
+    execute 'nmap <silent> <buffer>' . s:pre . 'rem :call sharpenup#legacycsproj#RenameInProject()<Left>'
   endif
 endif
 

--- a/ftplugin/cs/sharpenup.vim
+++ b/ftplugin/cs/sharpenup.vim
@@ -50,6 +50,11 @@ if get(g:, 'sharpenup_create_mappings', 1)
 
   call s:map('n', s:pre . 'rt', 'run_test')
   call s:map('n', s:pre . 'rat', 'run_tests_in_file')
+  
+  if g:sharpenup_legacy_csproj_actions
+    execute 'nmap <silent> <buffer>' . s:pre . '<LocalLeader>add :call sharpenup#legacycsproj#AddToProject()<CR>'
+    execute 'nmap <silent> <buffer>' . s:pre . '<LocalLeader>ren :call sharpenup#legacycsproj#RenameInProject()<Left>'
+  endif
 endif
 
 if g:sharpenup_codeactions
@@ -66,11 +71,6 @@ if g:sharpenup_codeactions
   augroup END
 
   let b:undo_ftplugin .= '| execute "autocmd! sharpenup_ftplugin * <buffer>"'
-endif
-
-if g:sharpenup_legacy_csproj_actions
-  nmap <silent> <buffer> <LocalLeader>add :call legacycsproj#AddToProject()<CR>
-  nmap <silent> <buffer> <LocalLeader>ren :call legacycsproj#RenameInProject()<Left>
 endif
 
 " vim:et:sw=2:sts=2

--- a/link.txt
+++ b/link.txt
@@ -1,0 +1,1 @@
+https://github.com/OmniSharp/omnisharp-vim/wiki/Working-with-older-.csproj-Projects

--- a/link.txt
+++ b/link.txt
@@ -1,1 +1,0 @@
-https://github.com/OmniSharp/omnisharp-vim/wiki/Working-with-older-.csproj-Projects

--- a/plugin/sharpenup.vim
+++ b/plugin/sharpenup.vim
@@ -11,6 +11,8 @@ let g:sharpenup_codeactions_glyph =
 \ get(g:, 'sharpenup_codeactions_glyph', '💡')
 let g:sharpenup_codeactions_set_signcolumn =
 \ get(g:, 'sharpenup_codeactions_set_signcolumn', 1)
+let g:sharpenup_legacy_csproj_actions =
+\ get(g:, 'sharpenup_legacy_csproj_actions', 1)
 
 if g:sharpenup_codeactions
   execute 'sign define sharpenup_CodeActions text=' .


### PR DESCRIPTION
- Added legacy csproj action functions as written by @nickspoons here https://github.com/OmniSharp/omnisharp-vim/wiki/Working-with-older-.csproj-Projects
- Added flag `g:sharpenup_legacy_csproj_actions` and load the mappings when the flag is set (mappings are also as suggested in the link above)