### PR TITLE
fix: prevent `E158: Invalid buffer name:`

### DIFF
--- a/autoload/sharpenup/codeactions.vim
+++ b/autoload/sharpenup/codeactions.vim
@@ -10,9 +10,13 @@ function! sharpenup#codeactions#Count() abort
 endfunction
 
 function! sharpenup#codeactions#CBReturnCount(count) abort
+  let file = expand('%:p')
+  if empty(file)
+    return
+  endif
   if a:count
     execute 'sign place 99 line=' . line('.')
-    \ 'name=sharpenup_CodeActions file=' . expand('%:p')
+    \ 'name=sharpenup_CodeActions file=' . file
   endif
 endfunction
 

--- a/autoload/sharpenup/codeactions.vim
+++ b/autoload/sharpenup/codeactions.vim
@@ -11,10 +11,7 @@ endfunction
 
 function! sharpenup#codeactions#CBReturnCount(count) abort
   let file = expand('%:p')
-  if empty(file)
-    return
-  endif
-  if a:count
+  if a:count && !empty(file)
     execute 'sign place 99 line=' . line('.')
     \ 'name=sharpenup_CodeActions file=' . file
   endif


### PR DESCRIPTION
Given `set updatetime=250`
When opening a quickfix window
The system currently echoes a `E158: Invalid buffer name:` message