### PR TITLE
remove "buffer with name foo!cmd.exe does not exist" error when usi GetCodeActions with fzf

### DIFF
--- a/autoload/sharpenup/codeactions.vim
+++ b/autoload/sharpenup/codeactions.vim
@@ -10,6 +10,10 @@ function! sharpenup#codeactions#Count() abort
 endfunction
 
 function! sharpenup#codeactions#CBReturnCount(count) abort
+  if &buftype == "terminal"
+    return
+  endif
+
   let file = expand('%:p')
   if a:count && !empty(file)
     execute 'sign place 99 line=' . line('.')


### PR DESCRIPTION
Oftentimes, by the time the "code actions" icon tries to be displayed, fzf already opened a terminal buffer and we're already in it.

This creates an error.